### PR TITLE
Added

### DIFF
--- a/src/main/resources/static/ajax/pages-armedis-management.html
+++ b/src/main/resources/static/ajax/pages-armedis-management.html
@@ -28,25 +28,27 @@
         </div>
 	
         <!-- 설정 테이블 -->
-        <table class="table table-striped" id="configTable">
-            <thead>
-                <tr>
-                    <th>설정 키</th>
-                    <th>현재값</th>
-                    <th>편집</th>
-                    <th>설명</th>
-	            </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+        <div class="table-responsive">
+            <table class="table table-striped" id="configTable">
+                <thead>
+                    <tr>
+                        <th>설정 키</th>
+                        <th>현재값</th>
+                        <th>편집</th>
+                        <th>설명</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
         <!-- 편집 모달 -->
-        <div class="modal fade" id="editModal" tabindex="-1" aria-hidden="true" style="position: fixed;">
+        <div class="modal" id="editModal" tabindex="-1" aria-hidden="true" style="position: fixed;">
         <!--      <div class="modal-dialog">-->
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="modalTitle" ></h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="설정 편집 닫기"></button>
                     </div>
                     <div class="modal-body">
                         <p>현재값: <span id="modalCurrent">-</span></p>
@@ -65,12 +67,12 @@
             </div>
         </div> 
         <!-- 로그인 모달 -->
-        <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true" style="position: fixed;">
+        <div class="modal" id="loginModal" tabindex="-1" aria-hidden="true" style="position: fixed;">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="loginModalTitle">Lock Screen</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="로그인 닫기"></button>
                     </div>
                     <div class="modal-body">
                         <div class="user-thumb text-center">
@@ -82,7 +84,7 @@
                             <input type="text" class="form-control" id="username" placeholder="Enter username" value="">
                         </div>
 
-                        <form>
+                        <form id="loginForm">
                             <div class="mb-3 position-relative">
                                 <label class="form-label" for="password-input">Password</label>
                                 <div class="position-relative auth-pass-inputgroup mb-3">
@@ -138,30 +140,62 @@
 	];
 
 	var tableBody = document.querySelector("#configTable tbody");
-	var editModal  = new bootstrap.Modal(document.getElementById("editModal"));
-    var loginModal = new bootstrap.Modal(document.getElementById("loginModal"), {
+    var editModalElement = document.getElementById("editModal");
+    var loginModalElement = document.getElementById("loginModal");
+	var editModal = new bootstrap.Modal(editModalElement);
+    var loginModal = new bootstrap.Modal(loginModalElement, {
         backdrop: 'static' // 바깥 클릭해도 닫히지 않음
     });
     var currentEdit = null;
 	var kvMap = {};
-	var editEventObject = null; //클릭 이벤트 객체
+    var pendingSave = null;
+    var currentEditReady = false;
+    var managementPageActive = true;
+    var configListController = null;
+    var configDetailController = null;
+    var configDetailRequestId = 0;
     
 	// 테이블 렌더링
 	function renderTable(category="All", filter="") {
-        tableBody.innerHTML = "";
+        tableBody.replaceChildren();
 
         if (!configKeys || configKeys.length === 0) {
             initTable();
         } else {
-            configKeys.filter(i => (category==="All" || i.category===category) && (i.key.includes(filter) || i.description.includes(filter)))
+            var normalizedFilter = filter.toLowerCase();
+            configKeys.filter(i => {
+                var key = String(i.key || "").toLowerCase();
+                var description = String(i.description || "").toLowerCase();
+                return (category === "All" || i.category === category)
+                    && (key.includes(normalizedFilter) || description.includes(normalizedFilter));
+            })
                     .forEach(i => {
                     var tr = document.createElement("tr");
-                    tr.innerHTML = `
-                        <td>${i.key}</td>
-                        <td><span class="current-value" data-key="${i.key}">${i.dataType === "memoryunit" ? getMemoryCapacityUnit(i.currentValue, "kbyte") : i.currentValue}</span></td>
-                        <td><button class="btn btn-sm btn-outline-primary edit-btn" data-key="${i.key}" data-cat="${i.category}">✏️</button></td>
-                        <td>${i.description}</td>
-                        `;
+                    var keyCell = document.createElement("td");
+                    var valueCell = document.createElement("td");
+                    var editCell = document.createElement("td");
+                    var descriptionCell = document.createElement("td");
+                    var currentValue = document.createElement("span");
+                    var editButton = document.createElement("button");
+
+                    keyCell.textContent = i.key;
+                    currentValue.className = "current-value";
+                    currentValue.dataset.key = i.key;
+                    currentValue.textContent = i.dataType === "memoryunit"
+                        ? getMemoryCapacityUnit(i.currentValue, "kbyte")
+                        : i.currentValue;
+                    valueCell.appendChild(currentValue);
+
+                    editButton.type = "button";
+                    editButton.className = "btn btn-sm btn-outline-primary edit-btn";
+                    editButton.dataset.key = i.key;
+                    editButton.dataset.cat = i.category;
+                    editButton.setAttribute("aria-label", i.key + " 설정 편집");
+                    editButton.textContent = "✏️";
+                    editCell.appendChild(editButton);
+
+                    descriptionCell.textContent = i.description;
+                    tr.append(keyCell, valueCell, editCell, descriptionCell);
                     tableBody.appendChild(tr);
                     });
             document.querySelectorAll(".edit-btn").forEach(btn => btn.addEventListener("click", openModal));
@@ -171,18 +205,31 @@
     // 모달 열기
     function openModal(e) {
         var event = e.currentTarget.dataset;
-        var itemsList = []; 
         var key = event.key;
-        var cat = event.cat;
-        currentEdit = configKeys.find(i => i.key === key);
+        var requestedEdit = configKeys.find(i => i.key === key);
+        if (!managementPageActive || !requestedEdit) {
+            return;
+        }
+
+        if (configDetailController) {
+            configDetailController.abort();
+        }
+        configDetailController = new AbortController();
+        var requestId = ++configDetailRequestId;
+
+        currentEdit = requestedEdit;
+        pendingSave = null;
+        currentEditReady = false;
+        document.getElementById("saveBtn").disabled = true;
+        document.getElementById("modalInputContainer").replaceChildren();
         $("#modalTitle").text(`${key} 설정 변경`);
         $("#modalCurrent").text("불러오는 중...");
         kvMap = {};
 
-        switch(currentEdit.dataType) {
+        switch(requestedEdit.dataType) {
             case "memoryunit":
-                $(".alert")[0].classList.remove("d-none");
-                $(".alert > #alertMsg")[0].innerText = 
+                document.querySelector("#editModal .alert").classList.remove("d-none");
+                document.querySelector("#editModal #alertMsg").innerText =
 `# 1k => 1000 bytes
 # 1kb => 1024 bytes
 # 1m => 1000000 bytes
@@ -191,21 +238,29 @@
 # 1gb => 1024*1024*1024 bytes`;
                 break;
             default:
-                $(".alert")[0].classList.add("d-none");
+                document.querySelector("#editModal .alert").classList.add("d-none");
         }
         editModal.show();
 
         // 조회
-        fetch("/v1/management/settings/config/" + key)
+        fetch("/v1/management/settings/config/" + encodeURIComponent(key), {
+            signal: configDetailController.signal
+        })
             .then(res=> {
                 if (!res.ok) {
-                    editModal.hide();
-                    console.error(res.statusText);
-                    alert("관리자에게 문의하세요");
+                    throw new Error("HTTP " + res.status);
                 }
                 return res.json();
             })
             .then(data=> {
+                if (!managementPageActive
+                    || requestId !== configDetailRequestId
+                    || currentEdit !== requestedEdit) {
+                    return;
+                }
+                if (!data.result || typeof data.result !== "object" || Object.keys(data.result).length === 0) {
+                    throw new Error("설정값 응답이 비어 있습니다.");
+                }
                 var currentKey = Object.keys(data.result)[0];
                 var currentVal = data.result[currentKey];
                 var viewCurrentVal = data.result[currentKey];
@@ -213,7 +268,7 @@
                     viewCurrentVal = numberWithCommas(currentVal);
                 }
                 
-                switch(currentEdit.dataType) {
+                switch(requestedEdit.dataType) {
                     case "memoryunit":
                         $("#modalCurrent").text(getMemoryCapacityUnit(currentVal, "kbyte"));
                         break;
@@ -221,51 +276,113 @@
                         $("#modalCurrent").text(viewCurrentVal);
                 }
 
-                if (currentEdit.dataType === "keyvalue") 
+                if (requestedEdit.dataType === "keyvalue")
                 try { 
                     kvMap = JSON.parse(currentVal);
                 } catch {
                     $("#modalCurrent").text("-");
                 };
-                renderModalInput(currentEdit, currentVal);
-                
+                renderModalInput(requestedEdit, currentVal);
+                currentEditReady = true;
+                document.getElementById("saveBtn").disabled = false;
             })
             .catch(err=> {
+                if (err.name === "AbortError"
+                    || !managementPageActive
+                    || requestId !== configDetailRequestId) {
+                    return;
+                }
                 console.error(err);
                 alert("관리자에게 문의하세요:" + err);
             	$("#modalCurrent").text("-");
                 editModal.hide();
+            })
+            .finally(() => {
+                if (requestId === configDetailRequestId) {
+                    configDetailController = null;
+                }
             });
 	}
 // 입력 컴포넌트 생성
 	function renderModalInput(cfg, curr) {
         var cont = document.getElementById("modalInputContainer");
-	    cont.innerHTML = "";
-        var html = "";
+        cont.replaceChildren();
+        var input = null;
+        var label = document.createElement("label");
+        label.className = "visually-hidden";
+        label.htmlFor = "modalInput";
+        label.textContent = cfg.key + " 새 값";
+
         switch(cfg.dataType) {
             case "integer":
-                html = `<input id="modalInput" type="number" class="form-control" value="${curr}">`;
+                input = document.createElement("input");
+                input.type = "number";
+                input.className = "form-control";
+                input.value = curr;
                 break;
             case "dropdown":
-                html = `<select id="modalInput" class="form-select">${cfg.options.map(o=>`<option value="${o}"${o===curr?' selected':''}>${o}</option>`).join('')}</select>`;
+                input = document.createElement("select");
+                input.className = "form-select";
+                cfg.options.forEach(optionValue => {
+                    var option = document.createElement("option");
+                    option.value = optionValue;
+                    option.textContent = optionValue;
+                    option.selected = optionValue === curr;
+                    input.appendChild(option);
+                });
                 break;
             case "toggle":
-                html = `<div class="form-check form-switch"><input id="modalInput" class="form-check-input" type="checkbox"${curr==='yes'?' checked':''}><label class="form-check-label">${cfg.description}</label></div>`;
+                var switchWrapper = document.createElement("div");
+                var switchLabel = document.createElement("label");
+                input = document.createElement("input");
+                switchWrapper.className = "form-check form-switch";
+                input.className = "form-check-input";
+                input.type = "checkbox";
+                input.checked = curr === "yes";
+                switchLabel.className = "form-check-label";
+                switchLabel.htmlFor = "modalInput";
+                switchLabel.textContent = cfg.description;
+                switchWrapper.append(input, switchLabel);
+                cont.appendChild(switchWrapper);
                 break;
             case "password":
-                html = `<input id="modalInput" type="password" class="form-control" placeholder="새 비밀번호">`;
+                input = document.createElement("input");
+                input.type = "password";
+                input.className = "form-control";
+                input.placeholder = "새 비밀번호";
                 break;
             case "string":
-                html = `<textarea id="modalInput" class="form-control" rows="3">${curr}</textarea>`;
+                input = document.createElement("textarea");
+                input.className = "form-control";
+                input.rows = 3;
+                input.value = curr;
                 break;
             case "keyvalue":
-                html = `<div id="kvContainer" class="mb-2"></div><button id="addKvBtn" class="btn btn-sm btn-outline-secondary mb-3">+ 추가</button>`;
+                var kvContainer = document.createElement("div");
+                var addButton = document.createElement("button");
+                kvContainer.id = "kvContainer";
+                kvContainer.className = "mb-2";
+                addButton.id = "addKvBtn";
+                addButton.type = "button";
+                addButton.className = "btn btn-sm btn-outline-secondary mb-3";
+                addButton.textContent = "+ 추가";
+                cont.append(kvContainer, addButton);
                 break;
             case "memoryunit":
-                html = `<input id="modalInput" type="text" class="form-control" value="${getMemoryCapacityUnit(curr, "kbyte")}">`;
+                input = document.createElement("input");
+                input.type = "text";
+                input.className = "form-control";
+                input.value = getMemoryCapacityUnit(curr, "kbyte");
                 break;
         }
-        cont.innerHTML = html;
+
+        if (input) {
+            input.id = "modalInput";
+            cont.prepend(label);
+            if (!input.parentElement) {
+                cont.appendChild(input);
+            }
+        }
         if (cfg.dataType === "keyvalue") initKeyValue();
     }
 
@@ -278,37 +395,89 @@
         };
 
         function renderKV() {
-            kvCont.innerHTML = "";
+            kvCont.replaceChildren();
             Object.entries(kvMap).forEach(([k,v]) => {
                 var row = document.createElement("div");
+                var keyInput = document.createElement("input");
+                var valueInput = document.createElement("input");
+                var removeButton = document.createElement("button");
+                var currentKey = k;
+
                 row.className = "d-flex mb-2";
-                row.innerHTML = `<input class="form-control me-2" data-key="key" value="${k}" placeholder="명령어">` +
-                                `<input class="form-control me-2" data-key="value" value="${v}" placeholder="새 이름">` +
-                                `<button class="btn btn-sm btn-danger">-</button>`;
-                row.querySelector("button").onclick=()=>{
-                    delete kvMap[k];
+                keyInput.className = "form-control me-2";
+                keyInput.dataset.key = "key";
+                keyInput.value = k;
+                keyInput.placeholder = "명령어";
+                keyInput.setAttribute("aria-label", "명령어");
+
+                valueInput.className = "form-control me-2";
+                valueInput.dataset.key = "value";
+                valueInput.value = v;
+                valueInput.placeholder = "새 이름";
+                valueInput.setAttribute("aria-label", "새 명령어 이름");
+
+                removeButton.type = "button";
+                removeButton.className = "btn btn-sm btn-danger";
+                removeButton.setAttribute("aria-label", (k || "빈 항목") + " 삭제");
+                removeButton.textContent = "-";
+                removeButton.onclick=()=>{
+                    delete kvMap[currentKey];
                     renderKV();
                 };
-                row.querySelectorAll("input").forEach(inp=>{
-                    inp.oninput=()=>{
-                        const newKey=row.querySelector("[data-key=key]").value;
-                        const newVal=row.querySelector("[data-key=value]").value;
-                        delete kvMap[k]; if(newKey) kvMap[newKey]=newVal; renderKV();
-                    };
-                });
+
+                keyInput.oninput=()=>{
+                    var newKey = keyInput.value;
+                    delete kvMap[currentKey];
+                    currentKey = newKey;
+                    if (currentKey) {
+                        kvMap[currentKey] = valueInput.value;
+                    }
+                };
+                valueInput.oninput=()=>{
+                    if (currentKey) {
+                        kvMap[currentKey] = valueInput.value;
+                    }
+                };
+
+                row.append(keyInput, valueInput, removeButton);
                 kvCont.appendChild(row);
             });
         }
         renderKV();
     }
 
-    // 저장 처리
-    document.getElementById("saveBtn").onclick=()=>{
+    function getCurrentEditValue() {
         var val;
         if (currentEdit.dataType === "toggle") val = document.getElementById("modalInput").checked ? "yes":"no";
         else if (currentEdit.dataType === "keyvalue") val = JSON.stringify(kvMap);
         else val = document.getElementById("modalInput").value;
-        
+        return val;
+    }
+
+    function isSuccessfulResult(result) {
+        return result && typeof result.result === "string" && result.result.toUpperCase() === "OK";
+    }
+
+    function setLoginBusy(isBusy) {
+        var loginButton = document.getElementById("saveLoginBtn");
+        var saveButton = document.getElementById("saveBtn");
+        if (loginButton) {
+            loginButton.disabled = isBusy;
+            loginButton.textContent = isBusy ? "처리 중..." : "LOGIN";
+        }
+        if (saveButton) {
+            saveButton.disabled = isBusy || !currentEditReady;
+        }
+    }
+
+    // 저장 처리
+    document.getElementById("saveBtn").onclick=()=>{
+        if (!managementPageActive || !currentEdit || !currentEditReady) {
+            alert("설정값을 불러온 후 다시 시도해주세요.");
+            return;
+        }
+        var val = getCurrentEditValue();
+
         if (val === "" || val === null || val === undefined) {
             alert("값을 입력해주세요");
             return;
@@ -328,6 +497,11 @@
                 return;
             }
         }
+        pendingSave = {
+            key: currentEdit.key,
+            dataType: currentEdit.dataType,
+            value: val
+        };
         //모달 창에 id, password 가 남아있어 지움
         document.getElementById("username").value = "";
         document.getElementById("password-input").value = "";
@@ -335,14 +509,15 @@
 	};
 
     // 로그인 처리
-    document.getElementById("saveLoginBtn").onclick=()=>{
-        var val;
-        if (currentEdit.dataType === "toggle") val = document.getElementById("modalInput").checked ? "yes":"no";
-        else if (currentEdit.dataType === "keyvalue") val = JSON.stringify(kvMap);
-        else val = document.getElementById("modalInput").value;
-
+    document.getElementById("saveLoginBtn").onclick=async ()=>{
+        var saveRequest = pendingSave;
         var id = document.getElementById("username").value;
         var pwd = document.getElementById("password-input").value;
+
+        if (!managementPageActive || !saveRequest) {
+            alert("저장할 설정을 다시 선택해주세요.");
+            return;
+        }
 
         if (id === "" || id === null || id === undefined) {
             alert("아이디를 입력해주세요");
@@ -357,51 +532,73 @@
         loginData.append("loginId", id);
         loginData.append("loginPassword", pwd);
 
-        //로그인 검증
-        fetch("/v1/management/login", {
-            method:"POST",
-            headers:{"Content-Type":"application/x-www-form-urlencoded"},
-            body: loginData.toString()
-        })
-        .then(res => res.json())
-        .then(loginRes => {
-            if (loginRes.hasOwnProperty("result") && loginRes.result.toUpperCase() === "OK") {
-                //저장
-                var saveData = new URLSearchParams();
-                saveData.append("value", val);
-                fetch("/v1/management/settings/config/" + currentEdit.key, {
-                    method:"PUT",
-                    headers:{"Content-Type":"application/x-www-form-urlencoded"},
-                    body: saveData.toString()
-                })
-                .then(res => res.json())
-                .then(saveRes => {
-                    document.querySelector(`.current-value[data-key="${currentEdit.key}"]`).textContent = val;
-                    loginModal.hide();
-                    editModal.hide();
-                    if (saveRes.hasOwnProperty("result") && saveRes.result.toUpperCase() === "OK") {
-                        alert("저장 성공하였습니다");
-                    } else {
-                        alert("저장 실패하였습니다");
-                    }
-                })
-                .catch(err => {
-                    alert("저장 실패하였습니다: " + err)
-                });
-            } else {
+        setLoginBusy(true);
+        try {
+            var loginResponse = await fetch("/v1/management/login", {
+                method:"POST",
+                headers:{"Content-Type":"application/x-www-form-urlencoded"},
+                body: loginData.toString()
+            });
+            if (!loginResponse.ok) {
+                throw new Error("HTTP " + loginResponse.status);
+            }
+            var loginResult = await loginResponse.json();
+            if (!isSuccessfulResult(loginResult)) {
                 alert("로그인 인증이 실패하였습니다");
                 return;
             }
-        })
-        .catch(err => {
-            alert("로그인 인증이 실패하였습니다");
-            console.error("로그인 인증이 실패하였습니다: ", err)
-        });
+            if (!managementPageActive) {
+                return;
+            }
+
+            var saveData = new URLSearchParams();
+            saveData.append("value", saveRequest.value);
+            var saveResponse = await fetch("/v1/management/settings/config/" + encodeURIComponent(saveRequest.key), {
+                method:"PUT",
+                headers:{"Content-Type":"application/x-www-form-urlencoded"},
+                body: saveData.toString()
+            });
+            if (!saveResponse.ok) {
+                throw new Error("HTTP " + saveResponse.status);
+            }
+            var saveResult = await saveResponse.json();
+            if (!isSuccessfulResult(saveResult)) {
+                alert("저장 실패하였습니다");
+                return;
+            }
+            if (!managementPageActive) {
+                return;
+            }
+
+            var currentValue = document.querySelector(`.current-value[data-key="${CSS.escape(saveRequest.key)}"]`);
+            if (currentValue) {
+                currentValue.textContent = saveRequest.value;
+            }
+            pendingSave = null;
+            loginModal.hide();
+            editModal.hide();
+            alert("저장 성공하였습니다");
+        } catch (error) {
+            console.error("설정 저장 실패:", error);
+            if (managementPageActive) {
+                alert("저장 실패하였습니다");
+            }
+        } finally {
+            if (managementPageActive) {
+                setLoginBusy(false);
+            }
+        }
 	};
+
+    document.getElementById("loginForm").addEventListener("submit", event => {
+        event.preventDefault();
+        document.getElementById("saveLoginBtn").click();
+    });
 
     // 검색이벤트	
     document.getElementById("searchInput").oninput = () => {
-        var cat = document.querySelector("#categoryTabs .nav-link.active").dataset.cat;
+        var activeTab = document.querySelector("#categoryTabs .nav-link.active");
+        var cat = activeTab ? activeTab.dataset.cat : "All";
         renderTable(cat,document.getElementById("searchInput").value);
     };
 
@@ -416,15 +613,27 @@
         var categories = data.map(item => item.category);
         var uniqueCategory = [...new Set(categories)];
         var ul = document.getElementById("categoryTabs");
-        var html = `<li class="nav-item"><a class="nav-link active" data-cat="All" href="#">전체</a></li>`;
-        uniqueCategory.forEach(category => {
-            html += `<li class="nav-item"><a class="nav-link" data-cat="${category}" href="#">${category}</a></li>`;
-        })
-        ul.innerHTML = html;
+        ul.replaceChildren();
+
+        function appendCategory(label, category, active) {
+            var listItem = document.createElement("li");
+            var link = document.createElement("a");
+            listItem.className = "nav-item";
+            link.className = "nav-link" + (active ? " active" : "");
+            link.dataset.cat = category;
+            link.href = "#";
+            link.textContent = label;
+            listItem.appendChild(link);
+            ul.appendChild(listItem);
+        }
+
+        appendCategory("전체", "All", true);
+        uniqueCategory.forEach(category => appendCategory(category, category, false));
 
 		// 탭 & 검색 이벤트
         ul.addEventListener("click", e => {
             if(e.target && e.target.matches(".nav-link")) {
+                e.preventDefault();
                 document.querySelectorAll("#categoryTabs .nav-link").forEach(t=>t.classList.remove("active")); 
                 e.target.classList.add("active"); 
                 renderTable(e.target.dataset.cat, document.getElementById("searchInput").value);
@@ -437,18 +646,38 @@
         return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     }
 	
-	// 조회
+    // 조회
     function getList() {
-        fetch("/v1/management/settings/configs")
-            .then(res => { 
+        if (configListController) {
+            configListController.abort();
+        }
+        configListController = new AbortController();
+        var controller = configListController;
+        fetch("/v1/management/settings/configs", { signal: controller.signal })
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error("HTTP " + res.status);
+                }
                 return res.json();
             })
             .then(data => {
+                if (!managementPageActive || controller !== configListController) {
+                    return;
+                }
                 setCategory(data.configKeys);
                 configKeys = data.configKeys;
                 renderTable("All");
             })
-            .catch(err =>alert("조회 실패 되었습니다: " + err));
+            .catch(err => {
+                if (err.name !== "AbortError" && managementPageActive) {
+                    alert("조회 실패 되었습니다: " + err);
+                }
+            })
+            .finally(() => {
+                if (controller === configListController) {
+                    configListController = null;
+                }
+            });
     }
 
     function initTable() {
@@ -462,9 +691,47 @@
         tableBody.appendChild(tr);
     }
 
-	// 처음 로드되었을 떄 
-    initTable();
-	getList();
+    function destroyManagementResources() {
+        managementPageActive = false;
+        configDetailRequestId++;
+        currentEditReady = false;
+        pendingSave = null;
+
+        if (configListController) {
+            configListController.abort();
+            configListController = null;
+        }
+        if (configDetailController) {
+            configDetailController.abort();
+            configDetailController = null;
+        }
+
+        [editModalElement, loginModalElement].forEach(modalElement => {
+            modalElement.classList.remove("show");
+            modalElement.style.display = "none";
+            modalElement.setAttribute("aria-hidden", "true");
+            modalElement.removeAttribute("aria-modal");
+            modalElement.removeAttribute("role");
+        });
+        editModal.dispose();
+        loginModal.dispose();
+        document.querySelectorAll(".modal-backdrop").forEach(backdrop => backdrop.remove());
+        document.body.classList.remove("modal-open");
+        document.body.style.removeProperty("overflow");
+        document.body.style.removeProperty("padding-right");
+    }
+
+    window.pageHooks = window.pageHooks || {};
+    window.pageHooks["pages-armedis-management.html"] = {
+        onLoad: function () {
+            managementPageActive = true;
+            initTable();
+            getList();
+        },
+        onUnload: function () {
+            destroyManagementResources();
+        }
+    };
 	
 </script>
 

--- a/src/main/resources/static/ajax/pages-armedis-overview.html
+++ b/src/main/resources/static/ajax/pages-armedis-overview.html
@@ -268,20 +268,22 @@
                         <h5 class="card-title mb-0"></h5>
                     </div>
                     <div class="card-body">
-                        <table id="nodes-datatables" class="display table table-bordered dt-responsive table-hover table-bordered" style="width:100%">
-                            <thead>
-                                <tr>
-                                    <th>Id</th>
-                                    <th>Address</th>
-                                    <th>Flags</th>
-                                    <th>Replica's Master</th>
-                                    <th>Ping was sent</th>
-                                    <th>Pong was received</th>
-                                    <th>State</th>
-                                    <th>Hash slot number or range</th>
-                                </tr>
-                            </thead>
-                        </table>
+                        <div class="table-responsive">
+                            <table id="nodes-datatables" class="display table table-bordered table-hover" style="width:100%">
+                                <thead>
+                                    <tr>
+                                        <th>Id</th>
+                                        <th>Address</th>
+                                        <th>Flags</th>
+                                        <th>Replica's Master</th>
+                                        <th>Ping was sent</th>
+                                        <th>Pong was received</th>
+                                        <th>State</th>
+                                        <th>Hash slot number or range</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div><!--end col-->
@@ -295,16 +297,18 @@
                     </div><!-- end card header -->
 
                     <div class="card-body">
-                        <table id="client-connections-datatables" class="display table table-bordered dt-responsive table-hover table-bordered" style="width:100%">
-                            <thead>
-                                <tr>
-                                    <th>Client</th>
-                                    <th>Total Duration</th>
-                                    <th>Idle time</th>
-                                    <th>Last command</th>
-                                </tr>
-                            </thead>
-                        </table>
+                        <div class="table-responsive">
+                            <table id="client-connections-datatables" class="display table table-bordered table-hover" style="width:100%">
+                                <thead>
+                                    <tr>
+                                        <th>Client</th>
+                                        <th>Total Duration</th>
+                                        <th>Idle time</th>
+                                        <th>Last command</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
                     </div><!-- end card-body -->
                 </div><!-- end card -->
             </div> <!-- end col -->
@@ -316,16 +320,18 @@
                     </div><!-- end card header -->
 
                     <div class="card-body">
-                        <table id="command-statistics-datatables" class="display table table-bordered dt-responsive table-hover table-bordered" style="width:100%">
-                            <thead>
-                                <tr>
-                                    <th>Command</th>
-                                    <th>Number of calls</th>
-                                    <th>Total Duration</th>
-                                    <th>Duration per call</th>
-                                </tr>
-                            </thead>
-                        </table>
+                        <div class="table-responsive">
+                            <table id="command-statistics-datatables" class="display table table-bordered table-hover" style="width:100%">
+                                <thead>
+                                    <tr>
+                                        <th>Command</th>
+                                        <th>Number of calls</th>
+                                        <th>Total Duration</th>
+                                        <th>Duration per call</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
                     </div><!-- end card-body -->
                 </div><!-- end card -->
             </div> <!-- end col -->
@@ -337,15 +343,17 @@
                     </div><!-- end card header -->
 
                     <div class="card-body">
-                        <table id="slow-queries-log-datatables" class="display table table-bordered dt-responsive table-hover table-bordered" style="width:100%">
-                            <thead>
-                                <tr>
-                                    <th>Timestamp</th>
-                                    <th>Duration</th>
-                                    <th>Command</th>
-                                </tr>
-                            </thead>
-                        </table>
+                        <div class="table-responsive">
+                            <table id="slow-queries-log-datatables" class="display table table-bordered table-hover" style="width:100%">
+                                <thead>
+                                    <tr>
+                                        <th>Timestamp</th>
+                                        <th>Duration</th>
+                                        <th>Command</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
                     </div><!-- end card-body -->
                 </div><!-- end card -->
             </div> <!-- end col -->
@@ -375,6 +383,10 @@
 
     var charts = {};
     var statsData = [];
+    var overviewPollTimeoutId = null;
+    var overviewPollInFlight = false;
+    var overviewPageActive = false;
+    var overviewAbortControllers = [];
     
     var networkInputSeries = {
         data: [0]
@@ -393,6 +405,35 @@
             data: [0]
         }]
     };
+
+    function getStatsSnapshot(offsetFromEnd = 0) {
+        if (!Array.isArray(statsData) || statsData.length === 0) {
+            return null;
+        }
+        var index = Math.max(statsData.length - 1 - offsetFromEnd, 0);
+        return statsData[index] || null;
+    }
+
+    function getStatsSection(section, offsetFromEnd = 0) {
+        var snapshot = getStatsSnapshot(offsetFromEnd);
+        return snapshot && snapshot.redisInfoList && snapshot.redisInfoList.sum
+            ? snapshot.redisInfoList.sum[section]
+            : null;
+    }
+
+    async function fetchOverviewJson(url) {
+        var controller = new AbortController();
+        overviewAbortControllers.push(controller);
+        try {
+            var response = await fetch(url, { signal: controller.signal });
+            if (!response.ok) {
+                throw new Error("HTTP " + response.status);
+            }
+            return await response.json();
+        } finally {
+            overviewAbortControllers = overviewAbortControllers.filter(item => item !== controller);
+        }
+    }
 
     /**
      * Datatables 옵션
@@ -504,6 +545,12 @@
         paging: false,
         info: false
     });
+    var overviewDatatables = [
+        nodesDatatables,
+        clientConnectionsDatatables,
+        commandStatisticsDatatables,
+        slowQueriesLogDatatables
+    ];
 
     // 차트 영역 생성
     function createChartCard(cardId, cardBodyTarget, chartType, series) {
@@ -659,46 +706,50 @@
     // Ops/Sec 설정
     function setOpsPerSec() {
         var cardId = "opsPerSecCard";
-        // 마지막 stats
-        var lastStatsSumStats = _.last(statsData).redisInfoList.sum.stats;
-
-        var opsPerSec = lastStatsSumStats.instantaneousOpsPerSec;
+        var lastStatsSumStats = getStatsSection("stats");
+        var opsPerSec = lastStatsSumStats ? lastStatsSumStats.instantaneousOpsPerSec : 0;
         setDataValue(cardId, opsPerSec);
     }
 
     // Connected Clients 설정
     function setConnectedClients() {
         var cardId = "connectedClientsCard";
-        // 5초전 stats
-        var fiveSecondsAgoStatsSumStats = _.nth(statsData, -6).redisInfoList.sum.stats;
-        // 마지막 stats
-        var lastStatsSumStats = _.last(statsData).redisInfoList.sum.stats;
-        // 5초전 totalConnectionsReceived 
-        var fiveSecondsAgoConnectedReceived = fiveSecondsAgoStatsSumStats.totalConnectionsReceived;
-        // 마지막 totalConnectionsReceived
+        var fiveSecondsAgoStatsSumStats = getStatsSection("stats", 5);
+        var lastStatsSumStats = getStatsSection("stats");
+        var lastStatsSumClients = getStatsSection("clients");
+        if (!lastStatsSumStats || !lastStatsSumClients) {
+            setDataValue(cardId, "0(0)");
+            return;
+        }
+
+        var fiveSecondsAgoConnectedReceived = fiveSecondsAgoStatsSumStats
+            ? fiveSecondsAgoStatsSumStats.totalConnectionsReceived
+            : lastStatsSumStats.totalConnectionsReceived;
         var lastConnectedReceived = lastStatsSumStats.totalConnectionsReceived;
-        // 마지막 totalConnectionsReceived - 5초전 totalConnectionsReceived
         var computedConnectedReceived = Math.max(lastConnectedReceived - fiveSecondsAgoConnectedReceived, 0);
-        var lastStatsSumClients = _.last(statsData).redisInfoList.sum.clients;
         setDataValue(cardId, `${lastStatsSumClients.connectedClients.toLocaleString()}(${computedConnectedReceived.toLocaleString()})`);
     }
 
     // Number of Keys 설정
     function setTotalKeys() {
         var cardId = "totalKeysCard";
-        var lastStatsSumKeyspace = _.last(statsData).redisInfoList.sum.keyspace;
-        setDataValue(cardId, lastStatsSumKeyspace['0'].keys.toLocaleString());
+        var lastStatsSumKeyspace = getStatsSection("keyspace");
+        var dbZero = lastStatsSumKeyspace && lastStatsSumKeyspace["0"];
+        setDataValue(cardId, dbZero ? dbZero.keys.toLocaleString() : "0");
     }
 
     // Network 설정
     function setNetwork() {
         var cardId = "networkCard";
-        var lastStatsSumStats = _.last(statsData).redisInfoList.sum.stats;
+        var lastStatsSumStats = getStatsSection("stats");
+        if (!lastStatsSumStats) {
+            return;
+        }
         
-        // 1Gb 기준
-        var total = 1024 * 1024 * 1024;
-        var input = lastStatsSumStats.instantaneousInputKbps.toFixed(2);
-        var output = lastStatsSumStats.instantaneousOutputKbps.toFixed(2);
+        // Redis 수치는 KB/s이므로 1GB/s를 KB 기준으로 환산한다.
+        var total = 1024 * 1024;
+        var input = Number(lastStatsSumStats.instantaneousInputKbps || 0).toFixed(2);
+        var output = Number(lastStatsSumStats.instantaneousOutputKbps || 0).toFixed(2);
 
         var inputPct = input / total * 100;
         var outputPct = output / total * 100;
@@ -734,8 +785,11 @@
         var cardId = "memoryCard";
         var parent = document.getElementById(cardId);
         if (parent) {
-            var memoryElement = parent.querySelector("#memoryBar");
-            var lastStatsSumMemory = _.last(statsData).redisInfoList.sum.memory;
+            var lastStatsSumMemory = getStatsSection("memory");
+            if (!lastStatsSumMemory) {
+                charts["memoryBar"].updateSeries([{ data: [0, 0, 0, 0, 0] }], true);
+                return;
+            }
     
             // Max Memory가 없는 경우 Card에 Alert표시
             if (lastStatsSumMemory.maxmemory > 0) {
@@ -745,13 +799,9 @@
                 parent.querySelector(".alert").classList.remove("d-none");
             }
             
-            series: [{
-                data: [0, 0, 0, 0, 0]
-            }],
-    
             charts["memoryBar"].updateOptions({
                 xaxis: {
-                    max: getMemoryCapacityUnit(lastStatsSumMemory.totalSystemMemory)
+                    max: Number(lastStatsSumMemory.totalSystemMemory || 0)
                 }
             }, true);
             charts["memoryBar"].updateSeries(
@@ -770,15 +820,21 @@
 
     function setUptime() {
         var cardId = "uptimeCard";
-        var lastStatsSumServer = _.last(statsData).redisInfoList.sum.server;
+        var lastStatsSumServer = getStatsSection("server");
+        if (!lastStatsSumServer) {
+            setDataValue(cardId, "-");
+            return;
+        }
         var duration = moment.duration(lastStatsSumServer.uptimeInSeconds, "seconds");
         setDataValue(cardId, duration.humanize());
     }
 
     // Keyspace 설정
     function setKeyspace() {
-        var lastStatsSumKeyspace = _.last(statsData).redisInfoList.sum.keyspace;
-        var { keys, expires } = lastStatsSumKeyspace[0];
+        var lastStatsSumKeyspace = getStatsSection("keyspace");
+        var dbZero = lastStatsSumKeyspace && lastStatsSumKeyspace["0"];
+        var keys = dbZero ? Number(dbZero.keys || 0) : 0;
+        var expires = dbZero ? Number(dbZero.expires || 0) : 0;
         var nonTTL = keys - expires;
         
         // keyspace Bar 배경색 변경
@@ -799,10 +855,14 @@
 
     // hitRate 설정
     function setHitRate() {
-        // 1초전 stats
-        var beforecondsAgoStatsSumStats = _.nth(statsData, -2).redisInfoList.sum.stats;
-        // 마지막 stats
-        var lastStatsSumStats = _.last(statsData).redisInfoList.sum.stats;
+        var beforecondsAgoStatsSumStats = getStatsSection("stats", 1);
+        var lastStatsSumStats = getStatsSection("stats");
+        if (!beforecondsAgoStatsSumStats || !lastStatsSumStats) {
+            $("#ksHits").css("width", "0%");
+            $("#hitsCount").text("0");
+            $("#missesCount").text("0");
+            return;
+        }
 
         // var keyspaceHits = lastStatsSumStats.keyspaceHits - beforecondsAgoStatsSumStats.keyspaceHits;
         // var keyspaceMisses = lastStatsSumStats.keyspaceMisses - beforecondsAgoStatsSumStats.keyspaceMisses;
@@ -810,9 +870,10 @@
         var keyspaceMisses = lastStatsSumStats.keyspaceMisses - beforecondsAgoStatsSumStats.keyspaceMisses;
         var newHitRate = keyspaceHits / (keyspaceHits + keyspaceMisses) * 100;
 
-        if (Number.isNaN(newHitRate)) {
+        if (!Number.isFinite(newHitRate)) {
             newHitRate = 0;
         }
+        newHitRate = Math.min(Math.max(newHitRate, 0), 100);
 
         $("#ksHits").css("width", Math.max(newHitRate) + "%");
         $("#hitsCount").text(keyspaceHits.toLocaleString());
@@ -822,24 +883,24 @@
     // Version 설정
     function setVersion() {
         var cardId = "versionCard";
-        var lastStatsSumServer = _.last(statsData).redisInfoList.sum.server;
-        setDataValue(cardId, lastStatsSumServer.redisVersion);
+        var lastStatsSumServer = getStatsSection("server");
+        setDataValue(cardId, lastStatsSumServer ? lastStatsSumServer.redisVersion : "-");
     }
 
     // Eviction Policy 설정
     function setEvictionPolicy() {
         var cardId = "evictionPolicyCard";
-        var lastStatsSumMemory = _.last(statsData).redisInfoList.sum.memory;
-        setDataValue(cardId, lastStatsSumMemory.maxmemoryPolicy);
+        var lastStatsSumMemory = getStatsSection("memory");
+        setDataValue(cardId, lastStatsSumMemory ? lastStatsSumMemory.maxmemoryPolicy : "-");
     }
 
     // Redis 정보 조회
     async function getStats() {
-        var response = await fetch("/v1/redis/stats");
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        var data = await response.json();
-        statsData = data;
+        var data = await fetchOverviewJson("/v1/redis/stats");
+        if (!overviewPageActive) {
+            return;
+        }
+        statsData = Array.isArray(data) ? data : [];
 
         setOpsPerSec();
         setConnectedClients();
@@ -855,13 +916,12 @@
 
     // Nodes 조회
     async function getNodes() {
-        var rowCnt = 6;
-        var response = await fetch("/v1/management/nodelist");
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        var data = await response.json();
-        if (data.result.length > 0) {
-            var datas = _.map(data.result, item => {
+        var data = await fetchOverviewJson("/v1/management/nodelist");
+        if (!overviewPageActive) {
+            return;
+        }
+        var results = Array.isArray(data.result) ? data.result : [];
+        var datas = _.map(results, item => {
                 return {
                     id: item.id,
                     address: `${item.ip}:${item.listenPort}@${item.clusterBusPort}`,
@@ -873,22 +933,24 @@
                     hashSlotNumberOrRange: `${item.shardSlotStart}-${item.shardSlotEnd}`
                 }
             });
-            
-            nodesDatatables.clear();
+
+        nodesDatatables.clear();
+        if (datas.length > 0) {
             nodesDatatables.rows.add(datas);
-            nodesDatatables.draw(false);
         }
+        nodesDatatables.draw(false);
     }
 
     // Client connections 조회
     async function getClientConnections() {
         var rowCnt = 20;
-        var response = await fetch(`/v1/management/clientlist/${rowCnt}`);
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        var data = await response.json();
-        if (data.result.length > 0) {
-            var last20Datas = _.takeRight(data.result, rowCnt);
+        var data = await fetchOverviewJson(`/v1/management/clientlist/${rowCnt}`);
+        if (!overviewPageActive) {
+            return;
+        }
+        var results = Array.isArray(data.result) ? data.result : [];
+        var last20Datas = _.takeRight(results, rowCnt);
+        if (last20Datas.length > 0) {
             last20Datas = _.map(last20Datas, item => {
                 var picked = _.pick(item, ['addressPort', 'age', 'idle', 'lastCommand']);
                 picked.age = `${picked.age.toLocaleString()} s`;
@@ -901,40 +963,41 @@
                 };
             });
 
-            clientConnectionsDatatables.clear();
-            clientConnectionsDatatables.rows.add(last20Datas);
-            clientConnectionsDatatables.draw(false);
         }
+        clientConnectionsDatatables.clear();
+        if (last20Datas.length > 0) {
+            clientConnectionsDatatables.rows.add(last20Datas);
+        }
+        clientConnectionsDatatables.draw(false);
     }
 
     // Command statistics 조회
     async function getCommandStatistics() {
-        var rowCnt = 20;
-        var response = await fetch("/v1/management/commandstats");
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        var data = await response.json();
-        if (data.statsList.length > 0) {
-            rowCnt = data.statsList.length;
-            var datas = _.map(data.statsList, item => {
+        var data = await fetchOverviewJson("/v1/management/commandstats");
+        if (!overviewPageActive) {
+            return;
+        }
+        var statsList = Array.isArray(data.statsList) ? data.statsList : [];
+        var datas = _.map(statsList, item => {
                 return formatRedisStat(item);
             });
 
-            commandStatisticsDatatables.clear();
+        commandStatisticsDatatables.clear();
+        if (datas.length > 0) {
             commandStatisticsDatatables.rows.add(datas);
-            commandStatisticsDatatables.draw(false);
         }
+        commandStatisticsDatatables.draw(false);
     }
 
     // Slow queries log 조회
     async function getSlowlog() {
         var rowCnt = 20;
-        var response = await fetch(`/v1/management/slowlog/${rowCnt}`);
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        var data = await response.json();
-        if (data.result.length > 0) {
-            var slowlogs = _.map(data.result, item => {
+        var data = await fetchOverviewJson(`/v1/management/slowlog/${rowCnt}`);
+        if (!overviewPageActive) {
+            return;
+        }
+        var results = Array.isArray(data.result) ? data.result : [];
+        var slowlogs = _.map(results, item => {
                 var cloned = _.clone(item);
                 var [timestamp, duration, commands] = _.pullAt(cloned, [1, 2, 3]);
                 return {
@@ -944,10 +1007,11 @@
                 }
             });
 
-            slowQueriesLogDatatables.clear();
+        slowQueriesLogDatatables.clear();
+        if (slowlogs.length > 0) {
             slowQueriesLogDatatables.rows.add(slowlogs);
-            slowQueriesLogDatatables.draw(false);
         }
+        slowQueriesLogDatatables.draw(false);
     }
 
     // Checks "myself,master"
@@ -958,7 +1022,7 @@
         var flagList = _.split(flags, ",");
 
         // Trim each flag
-        fflagList = _.map(flagList, f => _.trim(f));
+        flagList = _.map(flagList, f => _.trim(f));
 
         // Remove all internal whitespace
         flagList = _.map(flagList, f => _.replace(f, /\s+/g, ""));
@@ -1061,38 +1125,71 @@
         }
     }
 
-    // 페이지 로드됐을 때 interval Init
-    function intervalInit() {
-        getStats();
-        getNodes();
-        getClientConnections();
-        getCommandStatistics();
-        getSlowlog();
+    async function intervalInit() {
+        if (!overviewPageActive || overviewPollInFlight) {
+            return;
+        }
+
+        overviewPollInFlight = true;
+        try {
+            var results = await Promise.allSettled([
+                getStats(),
+                getNodes(),
+                getClientConnections(),
+                getCommandStatistics(),
+                getSlowlog()
+            ]);
+            results.forEach(result => {
+                if (result.status === "rejected" && result.reason && result.reason.name !== "AbortError") {
+                    console.error("Overview 데이터 갱신 실패:", result.reason);
+                }
+            });
+        } finally {
+            overviewPollInFlight = false;
+            if (overviewPageActive) {
+                overviewPollTimeoutId = setTimeout(intervalInit, 5000);
+            }
+        }
     }
 
-    function clearIntervalIds() {
-        if (window.globalIntervalIds.length > 0) {
-            window.globalIntervalIds.forEach(id => clearInterval(id));
-            window.globalIntervalIds = [];
+    function destroyOverviewResources() {
+        overviewPageActive = false;
+        if (overviewPollTimeoutId) {
+            clearTimeout(overviewPollTimeoutId);
+            overviewPollTimeoutId = null;
         }
+        overviewAbortControllers.forEach(controller => controller.abort());
+        overviewAbortControllers = [];
+
+        Object.values(charts).forEach(chart => {
+            if (chart && typeof chart.destroy === "function") {
+                chart.destroy();
+            }
+        });
+        charts = {};
+
+        overviewDatatables.forEach(datatable => {
+            if (datatable && typeof datatable.destroy === "function") {
+                datatable.destroy();
+            }
+        });
+        overviewDatatables = [];
+        nodesDatatables = null;
+        clientConnectionsDatatables = null;
+        commandStatisticsDatatables = null;
+        slowQueriesLogDatatables = null;
     }
 
     window.pageHooks = window.pageHooks || {};
     window.pageHooks["pages-armedis-overview.html"] = {
         onLoad: function () {
             initCard();
-            intervalInit();
             initChart();
-            
-            // 기존 interval 모두 제거
-            clearIntervalIds();
-            var intervalId = setInterval(() => {
-                intervalInit();
-            }, 5000);
-            window.globalIntervalIds.push(intervalId);
+            overviewPageActive = true;
+            intervalInit();
         },
         onUnload: function () {
-            clearIntervalIds();
+            destroyOverviewResources();
         }
     };
 </script>

--- a/src/main/resources/static/ajax/pages-armedis-realtime-stats.html
+++ b/src/main/resources/static/ajax/pages-armedis-realtime-stats.html
@@ -93,13 +93,15 @@
                     </div><!-- end card header -->
 
                     <div class="card-body">
-                        <table class="table table-bordered dt-responsive nowrap table-striped align-middle"
-                            style="width:100%">
-                            <thead>
-                                <tr></tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
+                        <div class="table-responsive">
+                            <table class="table table-bordered nowrap table-striped align-middle"
+                                style="width:100%">
+                                <thead>
+                                    <tr></tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
                     </div><!-- end card-body -->
                 </div><!-- end card -->
                 <!-- Analysis END -->
@@ -153,6 +155,12 @@
     var prevStatsData = [];
     var redisStatDatas = [];
     var statsData = [];
+    var realtimePollTimeoutId = null;
+    var realtimePollInFlight = false;
+    var realtimePageActive = false;
+    var realtimeStatsController = null;
+    var hiddenAt = null;
+    var lastRenderedPointX = {};
     var tpsSeries = [{ name: "TPS", data: [] }];
     var hitRateSeries = [{ name: "HitRate", data: [] }];
     var memorySeries = [
@@ -183,6 +191,18 @@
             ] 
         }
     ];
+
+    function hasStatsData() {
+        return Array.isArray(statsData) && statsData.length > 0;
+    }
+
+    function trimSeries(series, totalPoints) {
+        series.forEach(item => {
+            if (item.data.length > totalPoints) {
+                item.data.splice(0, item.data.length - totalPoints);
+            }
+        });
+    }
 
     // 차트 영역 생성
     function createChartCard(cardId, series) {
@@ -308,104 +328,113 @@
             charts[cardId] = new ApexCharts(chartElement, chartOptions);
             charts[cardId].render();
 
-            var lastX = series[0].data.length > 0 && series[0].data[series[0].data.length - 1].x;
-            var optionsUpdate = {
-                xaxis: { min: lastX - 60000, max: lastX }
-            };
             charts[cardId].updateSeries(series);
-            charts[cardId].updateOptions(optionsUpdate, false, true);
+            if (series[0].data.length > 0) {
+                var lastX = series[0].data[series[0].data.length - 1].x;
+                lastRenderedPointX[cardId] = lastX;
+                charts[cardId].updateOptions({
+                    xaxis: { min: lastX - 60000, max: lastX }
+                }, false, true);
+            } else {
+                delete lastRenderedPointX[cardId];
+            }
         }
     }
 
     // 차트 그리기
     function addDataPoint(cardId, series) {
-        if (!series || series.length === 0) return;
+        if (!series || series.length === 0 || !series[0].data.length) return;
 
-        // charts에 데이터 추가
-        var datas = series.map(elem => ({ data: [_.last(elem.data)] }));
-        if (charts[cardId] && datas.length > 0) {
-            charts[cardId].appendData(datas);
-            var lastX = series[0].data[series[0].data.length - 1].x;
+        var lastX = series[0].data[series[0].data.length - 1].x;
+        if (!charts[cardId] || lastRenderedPointX[cardId] === lastX) {
+            return;
+        }
 
-            var optionsUpdate = {
-                xaxis: { min: lastX - 60000, max: lastX }
+        var visibleSeries = series.map(item => ({
+            name: item.name,
+            data: item.data.slice(-60)
+        }));
+        charts[cardId].updateSeries(visibleSeries, false);
+        lastRenderedPointX[cardId] = lastX;
+
+        var optionsUpdate = {
+            xaxis: { min: lastX - 60000, max: lastX }
+        };
+
+        // ============================
+        // TPS Card
+        // ============================
+        if (cardId === "tpsCard") {
+            var allY = series[0].data.map(d => d.y);
+            var maxY = Math.max(...allY);
+            var adjustedMaxY = maxY * 1.1; // 10% 여유
+
+            // max값에 따라 100 또는 500단위로 조정
+            var step = adjustedMaxY > 500 ? 500 : 100;
+            var roundedMaxY = Math.ceil(adjustedMaxY / step) * step;
+
+            optionsUpdate.yaxis = {
+                min: 0,
+                max: roundedMaxY,
+                tickAmount: 5,
+                labels: {
+                    formatter: val => val.toFixed(0)
+                }
             };
 
-            // ============================
-            // TPS Card
-            // ============================
-            if (cardId === "tpsCard") {
-                var allY = series[0].data.map(d => d.y);
-                var maxY = Math.max(...allY);
-                var adjustedMaxY = maxY * 1.1; // 10% 여유
+        // ============================
+        // Memory Card
+        // ============================
+        } else if (cardId === "memoryCard") {
+            var allY = series.flatMap(s => s.data.map(d => d.y));
+            var maxY = Math.max(...allY);
+            var adjustedMaxY = maxY * 1.1;
 
-                // max값에 따라 100 또는 500단위로 조정
-                var step = adjustedMaxY > 500 ? 500 : 100;
-                var roundedMaxY = Math.ceil(adjustedMaxY / step) * step;
-
-                optionsUpdate.yaxis = {
-                    min: 0,
-                    max: roundedMaxY,
-                    tickAmount: 5,
-                    labels: {
-                        formatter: val => val.toFixed(0)
+            // Memory 단위: MB 또는 GB 자동 변환
+            optionsUpdate.yaxis = {
+                min: 0,
+                max: adjustedMaxY,
+                labels: {
+                    formatter: val => {
+                        return getMemoryCapacityUnit(val);
                     }
-                };
+                }
+            };
 
-            // ============================
-            // Memory Card
-            // ============================
-            } else if (cardId === "memoryCard") {
-                var allY = series.flatMap(s => s.data.map(d => d.y));
-                var maxY = Math.max(...allY);
-                var adjustedMaxY = maxY * 1.1;
+        // ============================
+        // HitRate Card
+        // ============================
+        } else if (cardId === "hitRateCard") {
+            optionsUpdate.yaxis = {
+                min: 0,
+                max: 100,
+                tickAmount: 5,
+                labels: { formatter: val => val.toFixed(0) + "%" }
+            };
 
-                // Memory 단위: MB 또는 GB 자동 변환
-                optionsUpdate.yaxis = {
-                    min: 0,
-                    max: adjustedMaxY,
-                    labels: {
-                        formatter: val => {
-                            return getMemoryCapacityUnit(val);
-                        }
-                    }
-                };
+        // ============================
+        // Received Connections Card
+        // ============================
+        } else if (cardId === "receivedConnectionsCard") {
+            var allY = series[0].data.map(d => d.y);
+            var maxY = Math.max(...allY);
+            var adjustedMaxY = maxY * 1.1; // 10% 여유
 
-            // ============================
-            // HitRate Card
-            // ============================
-            } else if (cardId === "hitRateCard") {
-                optionsUpdate.yaxis = {
-                    min: 0,
-                    max: 100,
-                    tickAmount: 5,
-                    labels: { formatter: val => val.toFixed(0) + "%" }
-                };
+            // max값에 따라 100 또는 500단위로 조정
+            var step = adjustedMaxY > 500 ? 500 : 100;
+            var roundedMaxY = Math.ceil(adjustedMaxY / step) * step;
 
-            // ============================
-            // Received Connections Card
-            // ============================
-            } else if (cardId === "receivedConnectionsCard") {
-                var allY = series[0].data.map(d => d.y);
-                var maxY = Math.max(...allY);
-                var adjustedMaxY = maxY * 1.1; // 10% 여유
-
-                // max값에 따라 100 또는 500단위로 조정
-                var step = adjustedMaxY > 500 ? 500 : 100;
-                var roundedMaxY = Math.ceil(adjustedMaxY / step) * step;
-
-                optionsUpdate.yaxis = {
-                    min: 0,
-                    max: roundedMaxY,
-                    tickAmount: 5,
-                    labels: {
-                        formatter: val => val.toLocaleString()
-                    }
-                };
-            }
-
-            charts[cardId].updateOptions(optionsUpdate, false, true);
+            optionsUpdate.yaxis = {
+                min: 0,
+                max: roundedMaxY,
+                tickAmount: 5,
+                labels: {
+                    formatter: val => val.toLocaleString()
+                }
+            };
         }
+
+        charts[cardId].updateOptions(optionsUpdate, false, true);
     }
 
     // card box 설정
@@ -429,8 +458,7 @@
     }
 
     // 차트 초기설정
-    async function initChart() {
-        await getStats();
+    function initChart() {
         setTPSData();
         createChartCard("tpsCard", _.cloneDeep(tpsSeries));
         
@@ -444,8 +472,8 @@
         createChartCard("receivedConnectionsCard", _.cloneDeep(receivedConnectionsSeries));
     }
 
-    // 차트 제거 후 재생성
-    function destroyChart() {
+    // 차트 제거 후 현재 데이터로 재생성
+    function rebuildCharts() {
         var cardIds = ["tpsCard", "hitRateCard", "memoryCard", "receivedConnectionsCard"];
 
         cardIds.forEach((elem, idx) => {
@@ -453,6 +481,7 @@
                 charts[elem].destroy();
                 delete charts[elem];
             }
+            delete lastRenderedPointX[elem];
 
             switch (idx) {
                 case 1: hitRateSeries[0].data = []; break;
@@ -466,7 +495,9 @@
             }
         });
 
-        initChart();
+        if (realtimePageActive) {
+            initChart();
+        }
     }
 
     // TPS 차트 데이터 설정
@@ -489,10 +520,7 @@
             }
         });
         
-        if (tpsSeries[0].data.length > totalPoints) {
-            tpsSeries[0].data.shift();
-            // tpsSeries[0].data = _.drop(tpsSeries[0].data, tpsSeries[0].data.length - totalPoints);
-        }
+        trimSeries(tpsSeries, totalPoints);
     }
 
     // Hit Rate 차트 데이터 설정
@@ -516,9 +544,10 @@
                     var keyspaceMisses = lastStatsSumStats.keyspaceMisses - beforeStats.keyspaceMisses;
                     var newHitRate = keyspaceHits / (keyspaceHits + keyspaceMisses) * 100;
         
-                    if (Number.isNaN(newHitRate)) {
+                    if (!Number.isFinite(newHitRate)) {
                         newHitRate = 0;
                     }
+                    newHitRate = Math.min(Math.max(newHitRate, 0), 100);
                     hitRateSeries[0].data.push({
                         x: curTime,
                         y: newHitRate
@@ -527,10 +556,7 @@
             }
         });
         
-        if (hitRateSeries[0].data.length > totalPoints) {
-            hitRateSeries[0].data.shift();
-            // hitRateSeries[0].data = _.drop(hitRateSeries[0].data, hitRateSeries[0].data.length - totalPoints);
-        }
+        trimSeries(hitRateSeries, totalPoints);
     }
 
     // Memory 차트 데이터 설정
@@ -570,12 +596,7 @@
             }
         });
 
-        memorySeries.forEach(elem => {
-            if (elem.data.length > totalPoints) {
-                elem.data.shift();
-                // elem.data = _.drop(elem.data, elem.data.length - totalPoints);
-            }
-        })
+        trimSeries(memorySeries, totalPoints);
     }
 
     // Received Connections 차트 데이터 설정
@@ -614,10 +635,7 @@
             }
         });
         
-        if (receivedConnectionsSeries[0].data.length > totalPoints) {
-            receivedConnectionsSeries[0].data.shift();
-            // receivedConnectionsSeries[0].data = _.drop(receivedConnectionsSeries[0].data, receivedConnectionsSeries[0].data.length - totalPoints);
-        }
+        trimSeries(receivedConnectionsSeries, totalPoints);
     }
 
     // Table 설정
@@ -670,14 +688,14 @@
             newItems = statsSum;
         } else {
             lastPrevItems = _.last(prevStatsData);
-            lastPrevDate = lastPrevItems.epochTime;
+            var lastPrevDate = lastPrevItems.epochTime;
             newItems = _.filter(statsSum, d => d.epochTime > lastPrevDate);    
         }
         
         newItems.map((elem, idx) => {
             var curTime = moment(elem.formatedEpochTime).format("HH:mm:ss");
             if(!_.some(redisStatDatas, { Time: curTime })) {
-                
+                var lastStatsSumStats = elem.redisInfoList.sum.stats;
                 var beforeStats;
                 if (!_.isEmpty(lastPrevItems)) {
                     beforeStats = lastPrevItems.redisInfoList.sum.stats;
@@ -685,19 +703,18 @@
                     if (idx > 0) {
                         beforeStats = newItems[idx - 1].redisInfoList.sum.stats;
                     } else {
-                        beforeStats = {}
+                        beforeStats = lastStatsSumStats;
                     }
                 }
-
-                var lastStatsSumStats = elem.redisInfoList.sum.stats;
 
                 // Hit Rate
                 var keyspaceHits = lastStatsSumStats.keyspaceHits - beforeStats.keyspaceHits || 0;
                 var keyspaceMisses = lastStatsSumStats.keyspaceMisses - beforeStats.keyspaceMisses || 0;
                 var newHitRate = keyspaceHits / (keyspaceHits + keyspaceMisses) * 100;
-                if (Number.isNaN(newHitRate)) {
+                if (!Number.isFinite(newHitRate)) {
                     newHitRate = 0;
                 }
+                newHitRate = Math.min(Math.max(newHitRate, 0), 100);
 
                 // Received Connections
                 // 1초전 totalConnectionsReceived 
@@ -758,7 +775,8 @@
                 var tableTd = document.createElement("td");
                 tableTd.textContent = "데이터가 없습니다.";
                 tableTd.style.textAlign = "center";
-                tableTd.colSpan = tableInfo.headers.length;
+                var tableConfig = tables.find(item => item.id === cardId);
+                tableTd.colSpan = tableConfig ? tableConfig.headers.length : 1;
                 tableTr.appendChild(tableTd);
 
                 tableTbody.innerHTML = "";
@@ -771,10 +789,18 @@
 
     // Redis 정보 조회
     async function getStats() {
-        var response = await fetch("/v1/redis/stats");
-        if (!response.ok) throw new Error("HTTP " + res.status);
-
-        statsData = await response.json();
+        if (realtimeStatsController) {
+            realtimeStatsController.abort();
+        }
+        realtimeStatsController = new AbortController();
+        try {
+            var response = await fetch("/v1/redis/stats", { signal: realtimeStatsController.signal });
+            if (!response.ok) throw new Error("HTTP " + response.status);
+            var data = await response.json();
+            statsData = Array.isArray(data) ? data : [];
+        } finally {
+            realtimeStatsController = null;
+        }
     }
 
     // Instance Information 데이터 설정
@@ -784,7 +810,17 @@
         var instanceInfoTableContent = ['version', 'mode', 'role', 'uptime', 'master_info', 'slave_info', 'aof_enable', 'hz', 'rdb_last_save_time', 'memory_policy', 'connected_clients', 'pid', 'maxclients', 'blocked_clients', 'mem_fragmentation_ratio'];
         var redisInfoHeaders = [];
         var redisHost = '';
-        var dataObj = Object.keys(statsData);
+        if (!hasStatsData()) {
+            var emptyCardBody = document.querySelector("#instanceInformation .card-body");
+            if (emptyCardBody) {
+                emptyCardBody.replaceChildren();
+                var emptyMessage = document.createElement("p");
+                emptyMessage.className = "text-muted mb-0";
+                emptyMessage.textContent = "데이터가 없습니다.";
+                emptyCardBody.appendChild(emptyMessage);
+            }
+            return;
+        }
 
         var lastStats = _.last(statsData).redisInfoList;
         var statsRedisServer = _.omit(lastStats, ["sum"]);
@@ -880,72 +916,111 @@
         var parent = document.getElementById(cardId);
         if (parent) {
             var cardBody = parent.querySelector(".card-body");
-            cardBody.innerHTML = "";
-            cardBody.appendChild(createTable(redisInfoHeaders, instanceInfoData, "table table-bordered dt-responsive nowrap table-striped align-middle", { width: "100%" }));
+            var tableWrapper = document.createElement("div");
+            tableWrapper.className = "table-responsive";
+            tableWrapper.appendChild(createTable(redisInfoHeaders, instanceInfoData, "table table-bordered nowrap table-striped align-middle", { width: "100%" }));
+            cardBody.replaceChildren(tableWrapper);
         }
     }
 
     async function intervalInit() {
-        await getStats();
-        setTPSData();
-        addDataPoint("tpsCard", tpsSeries)
-
-        setHitRateData();
-        addDataPoint("hitRateCard", hitRateSeries);
-        
-        setMemory();
-        addDataPoint("memoryCard", memorySeries);
-        
-        setReceivedConnectionsData();
-        addDataPoint("receivedConnectionsCard", receivedConnectionsSeries);
-
-        setRedisStat();
-        setInstanceInfo();
-    }
-
-    function clearIntervalIds() {
-        if (window.globalIntervalIds.length > 0) {
-            window.globalIntervalIds.forEach(id => clearInterval(id));
-            window.globalIntervalIds = [];
+        if (!realtimePageActive || realtimePollInFlight) {
+            return;
         }
-    }
 
-    // Life Cycle START
-    var hiddenAt = null; // 최소화 시작 시간 기록
-    window.pageHooks = window.pageHooks || {};
-    window.pageHooks["pages-armedis-realtime-stats.html"] = {
-        // 페이지가 로드 됐을 때
-        onLoad: function () {
-            initCard();
-            initChart();
-            initTableHeader();
-            
-            // 기존 interval 모두 제거
-            clearIntervalIds();
-            var intervalId = setInterval(intervalInit, 1000);
-            window.globalIntervalIds.push(intervalId);
-        },
-        // 페이지를 떠날 때
-        onUnload: function () {
-            clearIntervalIds();
-        }
-    };
+        realtimePollInFlight = true;
+        try {
+            await getStats();
+            if (!realtimePageActive) {
+                return;
+            }
 
-    document.addEventListener("visibilitychange", function() {
-        if (document.hidden) {
-            hiddenAt = Date.now();
-        } else {
-            var hiddenDuration = (Date.now() - hiddenAt) / 1000;
-            console.log(`브라우저가 ${hiddenDuration}초 동안 비활성화됨`);
+            setTPSData();
+            addDataPoint("tpsCard", tpsSeries);
 
-            // 특정 시간 이상일 때만 실행
-            if (hiddenDuration > 60) {
-                console.log("차트 재랜더링!");
-                
-                // 차트 제거 후 재랜더링
-                destroyChart();
+            setHitRateData();
+            addDataPoint("hitRateCard", hitRateSeries);
+
+            setMemory();
+            addDataPoint("memoryCard", memorySeries);
+
+            setReceivedConnectionsData();
+            addDataPoint("receivedConnectionsCard", receivedConnectionsSeries);
+
+            setRedisStat();
+            setInstanceInfo();
+        } catch (error) {
+            if (error.name !== "AbortError") {
+                console.error("Realtime 데이터 갱신 실패:", error);
+            }
+        } finally {
+            realtimePollInFlight = false;
+            if (realtimePageActive) {
+                realtimePollTimeoutId = setTimeout(intervalInit, 1000);
             }
         }
-    });
-    // Life Cycle END
+    }
+
+    async function initializeRealtimePage() {
+        try {
+            await getStats();
+            if (!realtimePageActive) {
+                return;
+            }
+            initChart();
+            setRedisStat();
+            setInstanceInfo();
+        } catch (error) {
+            if (error.name !== "AbortError") {
+                console.error("Realtime 초기화 실패:", error);
+            }
+        } finally {
+            if (realtimePageActive) {
+                realtimePollTimeoutId = setTimeout(intervalInit, 1000);
+            }
+        }
+    }
+
+    function handleRealtimeVisibilityChange() {
+        if (!realtimePageActive) {
+            return;
+        }
+        if (document.hidden) {
+            hiddenAt = Date.now();
+        } else if (hiddenAt !== null) {
+            var hiddenDuration = (Date.now() - hiddenAt) / 1000;
+            hiddenAt = null;
+            if (hiddenDuration > 60) {
+                rebuildCharts();
+            }
+        }
+    }
+
+    function destroyRealtimeResources() {
+        realtimePageActive = false;
+        if (realtimePollTimeoutId) {
+            clearTimeout(realtimePollTimeoutId);
+            realtimePollTimeoutId = null;
+        }
+        if (realtimeStatsController) {
+            realtimeStatsController.abort();
+            realtimeStatsController = null;
+        }
+        document.removeEventListener("visibilitychange", handleRealtimeVisibilityChange);
+        rebuildCharts();
+    }
+
+    window.pageHooks = window.pageHooks || {};
+    window.pageHooks["pages-armedis-realtime-stats.html"] = {
+        onLoad: function () {
+            realtimePageActive = true;
+            initCard();
+            initTableHeader();
+            document.addEventListener("visibilitychange", handleRealtimeVisibilityChange);
+            initializeRealtimePage();
+        },
+        onUnload: function () {
+            destroyRealtimeResources();
+        }
+    };
 </script>

--- a/src/main/resources/static/assets/js/ajax.js
+++ b/src/main/resources/static/assets/js/ajax.js
@@ -1,159 +1,198 @@
 /*
-Template Name: Armedis - Admin & Dashboard Template
-Author: Themesbrand
-Version: 3.5.0
-Website: https://Themesbrand.com/
-Contact: Themesbrand@gmail.com
-File: Ajax Js File
-*/
+ * Template Name: Armedis - Admin & Dashboard Template
+ * File: Ajax Js File
+ */
 
-var layoutSetupInitialized = false; // 플래그: 이벤트 리스너가 이미 등록되었는지 확인
+var layoutSetupInitialized = false;
+var currentPageUnload = null;
+var currentAjaxRequest = null;
+var requestedPage = null;
+var activePage = null;
+
+function getDefaultPage() {
+	return "pages-armedis-overview.html";
+}
+
+function normalizePage(page) {
+	var candidate = (page || "").replace(/^#/, "");
+	var knownLink = document.querySelector("#navbar-nav a[href='" + CSS.escape(candidate) + "']");
+
+	if (!/^[a-z0-9-]+\.html$/i.test(candidate) || !knownLink) {
+		return getDefaultPage();
+	}
+	return candidate;
+}
+
+function updateDocumentTitle(page) {
+	var titles = {
+		"pages-armedis-overview.html": "Overview",
+		"pages-armedis-realtime-stats.html": "Realtime Stats",
+		"pages-armedis-management.html": "Management"
+	};
+	document.title = (titles[page] || "Armedis") + " | Armedis";
+}
+
+function updateActiveMenu(page) {
+	$("#navbar-nav li, #navbar-nav li a").removeClass("active");
+	$("#two-column-menu li a").removeClass("active");
+	$("#navbar-nav li a").attr("aria-expanded", "false");
+
+	var navbar = document.getElementById("navbar-nav");
+	var link = navbar && navbar.querySelector('[href="' + page + '"]');
+	if (!link) {
+		return;
+	}
+
+	link.classList.add("active");
+	var parentCollapseDiv = link.closest(".collapse.menu-dropdown");
+	if (parentCollapseDiv) {
+		parentCollapseDiv.classList.add("show");
+		if (parentCollapseDiv.parentElement.children[0]) {
+			parentCollapseDiv.parentElement.children[0].classList.add("active");
+			parentCollapseDiv.parentElement.children[0].setAttribute("aria-expanded", "true");
+		}
+	}
+}
+
+function cleanupCurrentPage() {
+	if (typeof currentPageUnload === "function") {
+		try {
+			currentPageUnload();
+		} catch (error) {
+			console.error("onUnload error:", error);
+		}
+	}
+	currentPageUnload = null;
+}
+
+function renderPageLoadError(page) {
+	var result = document.getElementById("ajaxresult");
+	if (!result) {
+		return;
+	}
+
+	result.replaceChildren();
+	var wrapper = document.createElement("div");
+	wrapper.className = "page-content";
+
+	var alert = document.createElement("div");
+	alert.className = "alert alert-danger";
+	alert.setAttribute("role", "alert");
+	alert.textContent = page + " 화면을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.";
+
+	wrapper.appendChild(alert);
+	result.appendChild(wrapper);
+}
+
+function call_ajax_page(page, options) {
+	var settings = Object.assign({ updateHistory: true, force: false }, options);
+	var normalizedPage = normalizePage(page);
+
+	if (!settings.force && requestedPage === normalizedPage) {
+		return;
+	}
+
+	requestedPage = normalizedPage;
+	if (currentAjaxRequest) {
+		currentAjaxRequest.abort();
+		currentAjaxRequest = null;
+	}
+	cleanupCurrentPage();
+
+	currentAjaxRequest = $.ajax({
+		url: "/ajax/" + normalizedPage,
+		cache: false,
+		dataType: "html",
+		type: "GET"
+	}).done(function (data) {
+		if (settings.updateHistory && window.location.hash !== "#" + normalizedPage) {
+			window.history.pushState({ page: normalizedPage }, "", "#" + normalizedPage);
+		}
+
+		$("#ajaxresult").empty().html(data);
+		$(window).scrollTop(0);
+		activePage = normalizedPage;
+		updateDocumentTitle(normalizedPage);
+		updateActiveMenu(normalizedPage);
+
+		var hooks = window.pageHooks && window.pageHooks[normalizedPage];
+		if (hooks) {
+			if (typeof hooks.onLoad === "function") {
+				try {
+					hooks.onLoad();
+				} catch (error) {
+					console.error("onLoad error:", error);
+				}
+			}
+			if (typeof hooks.onUnload === "function") {
+				currentPageUnload = hooks.onUnload;
+			}
+		}
+	}).fail(function (_request, status) {
+		if (status !== "abort") {
+			activePage = null;
+			requestedPage = null;
+			renderPageLoadError(normalizedPage);
+		}
+	}).always(function () {
+		currentAjaxRequest = null;
+	});
+}
+
+function routeFromLocation() {
+	var rawPage = window.location.hash.replace(/^#/, "");
+	var page = normalizePage(rawPage);
+	if (rawPage !== page) {
+		window.history.replaceState({ page: page }, "", "#" + page);
+	}
+	if (page === requestedPage && page === activePage) {
+		return;
+	}
+	call_ajax_page(page, { updateHistory: false });
+}
 
 function setupLayout() {
-	// 이미 이벤트 리스너가 등록되었으면 다시 등록하지 않음
 	if (layoutSetupInitialized) {
 		return;
 	}
 	layoutSetupInitialized = true;
 
-	var menuLinks = document.querySelectorAll("#navbar-nav li a");
+	document.querySelectorAll("#navbar-nav li a").forEach(function (link) {
+		link.addEventListener("click", function (event) {
+			var page = link.getAttribute("href");
+			var target = link.getAttribute("target");
 
-	menuLinks.forEach(function (ele, i) {
-		ele.addEventListener("click", function (e) {
-			e.preventDefault()
-			var page = e.target.getAttribute("href");
-			var target = e.target.getAttribute("target");
-
-			if (!page && e.target.parentElement instanceof HTMLAnchorElement) {
-				page = e.target.parentElement.getAttribute("href");
-				target = e.target.parentElement.getAttribute("href");
+			if (!page || page.indexOf(".html") === -1) {
+				return;
+			}
+			if (target === "_blank" || target === "_self") {
+				return;
 			}
 
-			if (page.indexOf('.html') === -1) {
-				return false;
-			}
-
-			if (target == "_self") { window.location.href = page; return true };
-			if (target == "_blank") window.open(page, "_blank");
-			if (page == "javascript: void(0);") return false;
-
-			$("#navbar-nav li, #navbar-nav li a").removeClass("active");
-			$("#two-column-menu li a").removeClass("active");
-			$("#navbar-nav li a").attr("aria-expanded", "false");
-			if (page) {
-				// navbar-nav
-				var a = document.getElementById("navbar-nav").querySelector('[href="' + page + '"]');
-				if (a) {
-					if (document.documentElement.getAttribute("data-layout") == "twocolumn") {
-						a.classList.add("active");
-						var parentCollapseDiv = a.closest(".collapse.menu-dropdown");
-						if (parentCollapseDiv && parentCollapseDiv.parentElement.closest(".collapse.menu-dropdown")) {
-							parentCollapseDiv.classList.add("show");
-							parentCollapseDiv.parentElement.children[0].classList.add("active");
-							parentCollapseDiv.parentElement.children[0].setAttribute("aria-expanded", "true");
-							parentCollapseDiv.parentElement.closest(".collapse.menu-dropdown").parentElement.classList.add("twocolumn-item-show");
-							if (parentCollapseDiv.parentElement.parentElement.parentElement.parentElement.closest(".collapse.menu-dropdown")) {
-								var menuIdSub = parentCollapseDiv.parentElement.parentElement.parentElement.parentElement.closest(".collapse.menu-dropdown").getAttribute("id");
-								parentCollapseDiv.parentElement.parentElement.parentElement.parentElement.children[0].setAttribute("aria-expanded", "true");
-								parentCollapseDiv.parentElement.parentElement.parentElement.parentElement.closest(".collapse.menu-dropdown").parentElement.classList.add("twocolumn-item-show");
-								parentCollapseDiv.parentElement.closest(".collapse.menu-dropdown").parentElement.classList.remove("twocolumn-item-show");
-								if (document.getElementById("two-column-menu").querySelector('[href="#' + menuIdSub + '"]'))
-									document.getElementById("two-column-menu").querySelector('[href="#' + menuIdSub + '"]').classList.add("active");
-							}
-							var menuId = parentCollapseDiv.parentElement.closest(".collapse.menu-dropdown").getAttribute("id");
-							if (document.getElementById("two-column-menu").querySelector('[href="#' + menuId + '"]'))
-								document.getElementById("two-column-menu").querySelector('[href="#' + menuId + '"]').classList.add("active");
-						} else {
-							a.closest(".collapse.menu-dropdown").parentElement.classList.add("twocolumn-item-show");
-							var menuId = parentCollapseDiv.getAttribute("id");
-							if (document.getElementById("two-column-menu").querySelector('[href="#' + menuId + '"]'))
-								document.getElementById("two-column-menu").querySelector('[href="#' + menuId + '"]').classList.add("active");
-						}
-					} else {
-						a.classList.add("active");
-						var parentCollapseDiv = a.closest('.collapse.menu-dropdown');
-
-						if (parentCollapseDiv) {
-							parentCollapseDiv.classList.add("show");
-							parentCollapseDiv.parentElement.children[0].classList.add("active");
-							parentCollapseDiv.parentElement.children[0].setAttribute("aria-expanded", "true");
-							if (parentCollapseDiv.parentElement.closest('.collapse.menu-dropdown')) {
-								parentCollapseDiv.parentElement.closest(".collapse").classList.add("show");
-								if (parentCollapseDiv.parentElement.closest(".collapse").previousElementSibling)
-									parentCollapseDiv.parentElement.closest(".collapse").previousElementSibling.classList.add("active");
-							}
-						}
-					}
-				}
-			}
-			if (page == "javascript: void(0);") return false;
+			event.preventDefault();
 			call_ajax_page(page);
 		});
-	})
-}
-
-var currentPageUnload = null; // 이전 페이지 cleanup 함수 저장
-function call_ajax_page(page) {
-	if (typeof currentPageUnload === "function") {
-		try {
-			currentPageUnload();
-		} catch (e) {
-			console.error(e);
-		}
-		currentPageUnload = null;
-	}
-
-	$.ajax({
-		url: "/ajax/" + page,
-		cache: false,
-		dataType: "html",
-		type: "GET",
-		success: function (data) {
-			window.location.hash = page;
-			$("#ajaxresult").empty();
-			$("#ajaxresult").html(data);
-			$(window).scrollTop(0);
-
-			var hooks = window.pageHooks && window.pageHooks[page];
-			if (hooks) {
-				if (typeof hooks.onLoad === "function") {
-					try {
-						hooks.onLoad();
-					} catch (e) {
-						console.error("onLoad error: ", e);
-					}
-				}
-				if (typeof hooks.onUnload === "function") {
-					currentPageUnload = hooks.onUnload;
-				}
-			}
-		}
 	});
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-	// DOM이 준비된 후 setupLayout() 호출
+document.addEventListener("DOMContentLoaded", function () {
 	setupLayout();
-
-	var currentPage = document.location.hash;
-	if (currentPage) {
-		currentPage = currentPage.replace("#", "");
-		document.querySelector("#navbar-nav a[href='" + currentPage + "']") ? document.querySelector("#navbar-nav a[href='" + currentPage + "']").click() : call_ajax_page("pages-armedis-overview.html");
-	} else {
-		call_ajax_page("pages-armedis-overview.html");
-	}
+	routeFromLocation();
 });
 
-document.body.addEventListener("click", function (e) {
-	if(!e.target.closest("#navbar-nav")) {
-		if(e.target.hash) {
-			var urlHash = e.target.hash.replace("#", '');
-			if(document.querySelector("#navbar-nav a[href='" + urlHash + "']"))
-				document.querySelector("#navbar-nav a[href='" + urlHash + "']").click()
-		} else if(e.target.getAttribute("href")) {
-			if(document.querySelector("#navbar-nav a[href='" + e.target.getAttribute("href") + "']"))
-				document.querySelector("#navbar-nav a[href='" + e.target.getAttribute("href") + "']").click()
-		}
+window.addEventListener("popstate", routeFromLocation);
+window.addEventListener("hashchange", routeFromLocation);
+
+document.body.addEventListener("click", function (event) {
+	var link = event.target.closest("a[href]");
+	if (!link || link.closest("#navbar-nav")) {
+		return;
+	}
+
+	var page = link.hash ? link.hash.replace("#", "") : link.getAttribute("href");
+	var navLink = page && document.querySelector("#navbar-nav a[href='" + CSS.escape(page) + "']");
+	if (navLink) {
+		event.preventDefault();
+		call_ajax_page(page);
 	}
 });
-

--- a/src/main/resources/static/assets/js/app.js
+++ b/src/main/resources/static/assets/js/app.js
@@ -473,29 +473,6 @@ File: Main Js File
 		}
 	}
 
-	function call_ajax_page(page) {
-		if (page === "pages-armedis-overview.html") {
-			document.title = "Overiew |  Armedis";
-		} else {
-			var title = page.replace(".html", "");
-			var title1 = title.replace("-", " ");
-			document.title = title1.charAt(0).toUpperCase() + title1.slice(1) + " | Armedis";
-		}
-
-		$.ajax({
-			url: "/ajax/" + page,
-			cache: false,
-			dataType: "html",
-			type: "GET",
-			success: function (data) {
-				window.location.hash = page;
-				$("#ajaxresult").empty();
-				$("#ajaxresult").html(data);
-				$(window).scrollTop(0);
-			}
-		});
-	}
-
 	//  Search menu dropdown on Topbar
 	function isCustomDropdown() {
 		//Search bar
@@ -1902,9 +1879,6 @@ File: Main Js File
 			sessionStorage.setItem("defaultAttribute", JSON.stringify(isLayoutAttributes));
 			layoutSwitch(isLayoutAttributes);
 
-			// open right sidebar on first time load
-			var offCanvas = document.querySelector('.btn[data-bs-target="#theme-settings-offcanvas"]');
-			offCanvas ? offCanvas.click() : "";
 		} else {
 			var isLayoutAttributes = {};
 			isLayoutAttributes["data-layout"] = sessionStorage.getItem("data-layout");

--- a/src/main/resources/static/assets/js/common.js
+++ b/src/main/resources/static/assets/js/common.js
@@ -430,9 +430,10 @@ function createTable(headers, rows, className, styleObj) {
  * @returns 
  */
 function getMemoryCapacityUnit(size, unit = 'byte') {
-    // if (typeof size !== 'number' || size < 0) {
-    //   throw new Error('size는 0 이상의 숫자여야 합니다.');
-    // }
+    size = Number(size);
+    if (!Number.isFinite(size) || size < 0) {
+      size = 0;
+    }
   
     if (unit !== 'byte' && unit !== 'kbyte') {
       throw new Error("unit은 'byte' 또는 'kbyte' 중 하나여야 합니다.");

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-layout="vertical" data-topbar="light" data-sidebar="dark" data-sidebar-size="lg"
+<html lang="ko" data-layout="vertical" data-topbar="light" data-sidebar="dark" data-sidebar-size="lg"
     data-sidebar-image="none" data-preloader="disable">
 
 <head>
@@ -28,9 +28,9 @@
     <!-- App Css-->
     <link href="/assets/css/app.min.css" id="app-style" rel="stylesheet" type="text/css" />
     <!-- custom Css-->
-    <link href="/assets/css/custom.min.css" id="app-style" rel="stylesheet" type="text/css" />
+    <link href="/assets/css/custom.min.css" id="custom-style" rel="stylesheet" type="text/css" />
 
-    <link href="/assets/css/extra-css.css" id="app-style" rel="stylesheet" type="text/css" />
+    <link href="/assets/css/extra-css.css" id="extra-style" rel="stylesheet" type="text/css" />
 
 </head>
 
@@ -1000,7 +1000,7 @@
     <script src="/assets/js/app.js"></script>
     <script src="/assets/js/ajax.js"></script>
     <script>
-    console.log(document.domain);
+        document.getElementById("serverType").textContent = window.location.host;
     </script>
 </body>
 

--- a/src/test/java/com/github/armedis/ui/StaticUiRegressionTest.java
+++ b/src/test/java/com/github/armedis/ui/StaticUiRegressionTest.java
@@ -1,0 +1,152 @@
+package com.github.armedis.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+class StaticUiRegressionTest {
+
+    @Test
+    void routerSupportsBrowserHistoryAndUsesSinglePageLoader() throws IOException {
+        String ajax = resource("static/assets/js/ajax.js");
+        String app = resource("static/assets/js/app.js");
+
+        assertTrue(ajax.contains("window.addEventListener(\"popstate\", routeFromLocation)"));
+        assertTrue(ajax.contains("window.addEventListener(\"hashchange\", routeFromLocation)"));
+        assertTrue(ajax.contains("window.history.pushState"));
+        assertTrue(ajax.contains("window.history.replaceState({ page: page }, \"\", \"#\" + page)"));
+        assertFalse(app.contains("function call_ajax_page(page)"));
+    }
+
+    @Test
+    void managementRendersServerValuesWithoutHtmlTemplates() throws IOException {
+        String management = resource("static/ajax/pages-armedis-management.html");
+
+        assertFalse(management.contains("tr.innerHTML ="));
+        assertFalse(management.contains("row.innerHTML ="));
+        assertTrue(management.contains("currentValue.textContent"));
+        assertTrue(management.contains("descriptionCell.textContent"));
+        assertTrue(management.contains("input.value = curr"));
+    }
+
+    @Test
+    void managementUpdatesDisplayedValueOnlyAfterSuccessfulSave() throws IOException {
+        String management = resource("static/ajax/pages-armedis-management.html");
+        int successfulResultCheck = management.indexOf("if (!isSuccessfulResult(saveResult))");
+        int displayedValueUpdate = management.indexOf("currentValue.textContent = saveRequest.value");
+
+        assertTrue(successfulResultCheck >= 0);
+        assertTrue(displayedValueUpdate > successfulResultCheck);
+        assertTrue(management.contains("loginButton.disabled = isBusy"));
+    }
+
+    @Test
+    void managementWaitsForTheMatchingDetailResponseBeforeSaving() throws IOException {
+        String management = resource("static/ajax/pages-armedis-management.html");
+        int saveDisabled = management.indexOf("document.getElementById(\"saveBtn\").disabled = true");
+        int detailFetch = management.indexOf("fetch(\"/v1/management/settings/config/\"");
+        int matchingEditCheck = management.indexOf("currentEdit !== requestedEdit");
+        int editReady = management.indexOf("currentEditReady = true", detailFetch);
+
+        assertTrue(saveDisabled >= 0);
+        assertTrue(detailFetch > saveDisabled);
+        assertTrue(matchingEditCheck > detailFetch);
+        assertTrue(editReady > matchingEditCheck);
+        assertTrue(management.contains("var saveRequest = pendingSave"));
+        assertTrue(management.contains("encodeURIComponent(saveRequest.key)"));
+    }
+
+    @Test
+    void managementCleansUpRequestsAndModalsOnUnload() throws IOException {
+        String management = resource("static/ajax/pages-armedis-management.html");
+
+        assertTrue(management.contains("configListController.abort()"));
+        assertTrue(management.contains("configDetailController.abort()"));
+        assertTrue(management.contains("editModal.dispose()"));
+        assertTrue(management.contains("loginModal.dispose()"));
+        assertTrue(management.contains("\"pages-armedis-management.html\""));
+        assertTrue(management.contains("onUnload: function ()"));
+        assertFalse(management.contains("class=\"modal fade\""));
+    }
+
+    @Test
+    void realtimeRendersOnlyNewTimestampsAndKeepsSixtyPoints() throws IOException {
+        String realtime = resource("static/ajax/pages-armedis-realtime-stats.html");
+
+        assertTrue(realtime.contains("lastRenderedPointX[cardId] === lastX"));
+        assertTrue(realtime.contains("data: item.data.slice(-60)"));
+        assertTrue(realtime.contains("lastRenderedPointX[cardId] = lastX"));
+        assertFalse(realtime.contains(".appendData("));
+    }
+
+    @Test
+    void overviewDestroysEveryDataTableOnUnload() throws IOException {
+        String overview = resource("static/ajax/pages-armedis-overview.html");
+
+        assertTrue(overview.contains("var overviewDatatables = ["));
+        assertTrue(overview.contains("overviewDatatables.forEach(datatable =>"));
+        assertTrue(overview.contains("datatable.destroy()"));
+        assertTrue(overview.contains("overviewDatatables = []"));
+    }
+
+    @Test
+    void pollingIsSerializedAndLifecycleResourcesAreRemoved() throws IOException {
+        String overview = resource("static/ajax/pages-armedis-overview.html");
+        String realtime = resource("static/ajax/pages-armedis-realtime-stats.html");
+
+        assertFalse(overview.contains("setInterval(() =>"));
+        assertFalse(realtime.contains("setInterval(intervalInit"));
+        assertTrue(overview.contains("setTimeout(intervalInit, 5000)"));
+        assertTrue(realtime.contains("setTimeout(intervalInit, 1000)"));
+        assertTrue(realtime.contains("removeEventListener(\"visibilitychange\""));
+        assertFalse(overview.contains("\"HTTP \" + res.status"));
+        assertFalse(realtime.contains("\"HTTP \" + res.status"));
+    }
+
+    @Test
+    void tablesStayInsideResponsiveContainersAndCustomizerDoesNotAutoOpen() throws IOException {
+        String overview = resource("static/ajax/pages-armedis-overview.html");
+        String realtime = resource("static/ajax/pages-armedis-realtime-stats.html");
+        String management = resource("static/ajax/pages-armedis-management.html");
+        String app = resource("static/assets/js/app.js");
+
+        assertTrue(countOccurrences(overview, "class=\"table-responsive\"") >= 4);
+        assertTrue(countOccurrences(realtime, "table-responsive") >= 2);
+        assertTrue(countOccurrences(management, "class=\"table-responsive\"") >= 1);
+        assertFalse(app.contains("offCanvas ? offCanvas.click()"));
+    }
+
+    @Test
+    void memoryChartKeepsNumericAxisValues() throws IOException {
+        String overview = resource("static/ajax/pages-armedis-overview.html");
+        String common = resource("static/assets/js/common.js");
+
+        assertTrue(overview.contains("max: Number(lastStatsSumMemory.totalSystemMemory || 0)"));
+        assertTrue(common.contains("size = Number(size)"));
+        assertTrue(common.contains("Number.isFinite(size)"));
+    }
+
+    private static String resource(String path) throws IOException {
+        try (InputStream stream = StaticUiRegressionTest.class.getClassLoader().getResourceAsStream(path)) {
+            if (stream == null) {
+                throw new IOException("Resource not found: " + path);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static int countOccurrences(String text, String value) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(value, index)) >= 0) {
+            count++;
+            index += value.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
UI 페이지 종료 수명주기 훅 추가
Management 요청 취소 및 모달 리소스 정리 기능 추가
잘못된 URL 해시를 기본 Overview 경로로 교정하는 기능 추가
UI 정적 회귀 테스트 10개 추가
Changed
공통 라우팅
중복된 AJAX 페이지 로더를 하나로 통합
브라우저 뒤로가기·앞으로가기 지원
페이지 이동 시 문서 제목과 활성 메뉴 자동 갱신
허용된 UI 페이지만 로드하도록 경로 검증 강화
페이지 전환 시 이전 요청과 페이지 리소스 정리
페이지 로드 실패 시 사용자 오류 메시지 표시
초기 화면에서 테마 설정 패널이 자동으로 열리지 않도록 변경
Management
API 응답값을 textContent 기반으로 렌더링하도록 변경
설정 키를 URL에 사용할 때 안전하게 인코딩
설정 상세 조회가 완료되기 전까지 저장 버튼 비활성화
설정 키와 입력값을 저장 요청 전에 스냅샷으로 보관
로그인 및 저장 요청을 비동기 순서로 직렬화
저장 성공 이후에만 화면의 현재값 갱신
로그인·저장 진행 중 중복 제출 방지
모달과 편집 버튼의 접근성 레이블 개선
모바일 환경에서 설정 테이블 내부 가로 스크롤 지원
AJAX 페이지 전환과 충돌하지 않도록 모달 애니메이션 제거
Overview
통계 응답이 비어 있거나 표본 수가 부족한 경우 기본값 표시
중복 폴링을 방지하고 요청 완료 후 다음 폴링을 예약하도록 변경
페이지 이탈 시 진행 중인 API 요청 중단
페이지 이탈 시 ApexCharts 및 DataTable 인스턴스 정리
페이지 비활성 상태에서 지연 응답의 DOM 반영 방지
네트워크 통계 단위 계산 수정
메모리 차트 축을 숫자 값으로 유지
Nodes, Client Connections, Command Statistics, Slow Log 테이블의 모바일 반응형 처리 Realtime Stats
setInterval 기반 폴링을 직렬 setTimeout 방식으로 변경
동일한 타임스탬프의 차트 포인트 중복 추가 방지
차트 데이터별 최대 60개 포인트 유지
페이지 이탈 시 요청·타이머·차트·이벤트 리스너 정리
빈 통계와 빈 Instance Information 응답 처리
Analysis 및 Instance Information 테이블의 모바일 반응형 처리
장시간 숨겨진 탭 복귀 시 차트 재구성
공통 UI
문서 언어를 한국어로 변경
중복된 스타일시트 ID 제거
현재 UI 서버 주소를 헤더에 표시
메모리 단위 변환 시 문자열 입력을 숫자로 변환하고 비정상 값 처리
모바일 화면에서 문서 전체 가로 넘침 방지
Fixed
페이지별 폴링과 이벤트가 화면 전환 후에도 남는 문제
브라우저 뒤로가기 시 URL과 화면이 불일치하는 문제
서버 응답값을 HTML 문자열에 삽입하면서 발생할 수 있는 XSS 위험
인증 또는 설정 저장 실패 시 화면값이 먼저 변경되는 문제
서로 다른 설정의 비동기 응답이 뒤섞여 잘못된 설정값을 저장할 수 있는 문제
Realtime 차트 데이터가 장시간 계속 누적되는 문제
Overview 재진입 시 DataTable 인스턴스가 누적되는 문제
열린 모달에서 즉시 페이지를 이탈할 때 backdrop과 modal-open 상태가 남는 문제 Bootstrap 모달 전환 완료 후 제거된 DOM에 접근하며 발생하던 콘솔 오류
모바일 화면에서 넓은 표가 문서 전체 폭을 확장하는 문제